### PR TITLE
fix: detail view prevents scrolling

### DIFF
--- a/src/TrfPrjSummaryView.tsx
+++ b/src/TrfPrjSummaryView.tsx
@@ -194,7 +194,11 @@ export const TrfPrjSummaryView = (props: TrfPrjSummaryViewProps) => {
         <Bar size={6} style={{ background: 'currentColor', cursor: 'col-resize' }} />
         <Section minSize={50}>
           {!listSelectedItem && <div>No pkg selected</div>}
-          {listSelectedItem && <TrfDetailView items={props.items} selected={listSelectedItem} trf={props.trf} />}
+          {listSelectedItem && (
+            <div style={{ height: '100%', width: '100%', display: 'grid' }}>
+              <TrfDetailView items={props.items} selected={listSelectedItem} trf={props.trf} />
+            </div>
+          )}
         </Section>
       </Container>
     </div>

--- a/src/TrfWorkbenchView.tsx
+++ b/src/TrfWorkbenchView.tsx
@@ -315,11 +315,13 @@ export const TrfWorkbenchView = (props: TrfWorkbenchProps) => {
                   <Bar size={6} style={{ background: 'currentColor', cursor: 'col-resize' }} />
                   <Section minSize={50}>
                     {listSelectedItem && (
-                      <TrfDetailView
-                        items={rootReportItems}
-                        selected={listSelectedItem ? listSelectedItem : rootReportItems[0]}
-                        trf={props.trf}
-                      />
+                      <div style={{ height: '100%', width: '100%', display: 'grid' }}>
+                        <TrfDetailView
+                          items={rootReportItems}
+                          selected={listSelectedItem ? listSelectedItem : rootReportItems[0]}
+                          trf={props.trf}
+                        />
+                      </div>
                     )}
                   </Section>
                 </Container>


### PR DESCRIPTION
If the detail view was too wide it prevented scrolling in the list view.

Wrapped DetailView in a div with 100%/100%/grid.